### PR TITLE
removed refactorlog from solution structure

### DIFF
--- a/Project Files/MockQuizDatabase/MockQuizDatabase.sqlproj
+++ b/Project Files/MockQuizDatabase/MockQuizDatabase.sqlproj
@@ -64,7 +64,4 @@
     <Build Include="dbo\Tables\Questions.sql" />
     <Build Include="dbo\Tables\Answers.sql" />
   </ItemGroup>
-  <ItemGroup>
-    <RefactorLog Include="MockQuizDatabase.refactorlog" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
I did not initially include the database project refactor log in my GitHub repository, because I wasn't sure whether or not it contained sensitive security information and whether or not it was needed to build the application. The solution file, however, still remembered the refactor log and, therefore, prevented the database from building properly. I deleted the refactor log from the solution file's structure which should allow the database project to build successfully. 